### PR TITLE
Redesign site: Swiss-minimal editorial direction

### DIFF
--- a/next-site/app/about/page.tsx
+++ b/next-site/app/about/page.tsx
@@ -4,70 +4,81 @@ export const metadata = {
 
 export default function AboutPage() {
   return (
-    <div>
-      <img src="/assets/banner-ice.png" className="relative inline-block w-full py-2" alt="Ice banner" />
+    <div className="site">
+      <section className="ab-intro">
+        <div className="ab-intro-wrap">
+          <span className="eyebrow">About</span>
+          <div className="ab-banner">
+            <img src="/assets/banner-ice.png" alt="Ice banner" />
+          </div>
+        </div>
+      </section>
 
-      <h2 className="mb-6 mt-12 font-sans text-[2.074rem] font-bold leading-[0.9] tracking-[-0.025em] text-heading">
-        Work
-      </h2>
-      <p className="mb-8 p-0 leading-[1.625] text-text">
-        I&apos;m a co-founder of <a href="https://axle.energy/" className="text-primary hover:text-coral">axle energy</a>, where
-        we&apos;re building clever software to shift energy usage to low carbon, low cost
-        times. Please <a href="mailto:archy@axle.energy" className="text-primary hover:text-coral">reach out</a> if you&apos;re
-        interested in working together (we&apos;re hiring engineers!).
-      </p>
-      <p className="mb-8 p-0 leading-[1.625] text-text">
-        I previously led data science and product at
-        <a href="https://www.carbonchain.io" className="text-primary hover:text-coral"> CarbonChain</a>, a London-based startup
-        building carbon footprinting software for ultra-high-emitting supply chains.
-      </p>
-      <p className="mb-8 p-0 leading-[1.625] text-text">
-        I&apos;ve also worked on on global emissions monitoring as part of Vice President
-        Al Gore&apos;s <a href="https://www.climatetrace.org" className="text-primary hover:text-coral"> Climate TRACE </a>project,
-        and in applied ML research and product management at
-        <a href="https://www.elementai.com" className="text-primary hover:text-coral"> Element AI </a>. I&apos;ve also done stints as
-        a consultant for interesting climate tech companies like{' '}
-        <a href="https://www.transitionzero.org" className="text-primary hover:text-coral">Transition Zero</a>,{' '}
-        <a href="https://www.habitat.energy" className="text-primary hover:text-coral">Habitat</a>, and{' '}
-        <a href="https://www.origamienergy.com" className="text-primary hover:text-coral"> Origami Energy </a>.
-      </p>
+      <section className="ab-blocks">
+        <div className="ab-block">
+          <div className="ab-block-label">Work</div>
+          <div className="ab-block-body">
+            <p>
+              I&apos;m a co-founder of{' '}
+              <a href="https://axle.energy/">axle energy</a>, where we&apos;re building clever
+              software to shift energy usage to low carbon, low cost times. Please{' '}
+              <a href="mailto:archy@axle.energy">reach out</a> if you&apos;re interested in working
+              together (we&apos;re hiring engineers!).
+            </p>
+            <p>
+              I previously led data science and product at{' '}
+              <a href="https://www.carbonchain.io">CarbonChain</a>, a London-based startup building
+              carbon footprinting software for ultra-high-emitting supply chains.
+            </p>
+            <p>
+              I&apos;ve also worked on on global emissions monitoring as part of Vice President Al
+              Gore&apos;s <a href="https://www.climatetrace.org">Climate TRACE</a> project, and in
+              applied ML research and product management at{' '}
+              <a href="https://www.elementai.com">Element AI</a>. I&apos;ve also done stints as a
+              consultant for interesting climate tech companies like{' '}
+              <a href="https://www.transitionzero.org">Transition Zero</a>,{' '}
+              <a href="https://www.habitat.energy">Habitat</a>, and{' '}
+              <a href="https://www.origamienergy.com">Origami Energy</a>.
+            </p>
+          </div>
+        </div>
 
-      <h2 className="mb-6 mt-12 font-sans text-[2.074rem] font-bold leading-[0.9] tracking-[-0.025em] text-heading">
-        Academic
-      </h2>
-      <p className="mb-8 p-0 leading-[1.625] text-text">
-        I have a PhD in Neuroscience from University College London, and an undergrad in
-        Natural Sciences from Pembroke College, Cambridge. You can find my academic
-        contributions on my{' '}
-        <a
-          href="https://scholar.google.co.uk/citations?user=P9U_azIAAAAJ&hl=en"
-          className="text-primary hover:text-coral"
-        >
-          Google Scholar profile
-        </a>
-        .
-      </p>
+        <div className="ab-block">
+          <div className="ab-block-label">Academic</div>
+          <div className="ab-block-body">
+            <p>
+              I have a PhD in Neuroscience from University College London, and an undergrad in
+              Natural Sciences from Pembroke College, Cambridge. You can find my academic
+              contributions on my{' '}
+              <a href="https://scholar.google.co.uk/citations?user=P9U_azIAAAAJ&hl=en">
+                Google Scholar profile
+              </a>
+              .
+            </p>
+          </div>
+        </div>
 
-      <h2 className="mb-6 mt-12 font-sans text-[2.074rem] font-bold leading-[0.9] tracking-[-0.025em] text-heading">
-        Adventures
-      </h2>
-      <p className="mb-8 p-0 leading-[1.625] text-text">
-        When I&apos;m not at a keyboard, I&apos;m usually outside doing some combination of:
-      </p>
-      <ul className="mb-8 inline list-none p-0 text-center text-[1.728rem] leading-[0.5]">
-        <li className="mb-4">🚵🏻‍♂️</li>
-        <li className="mb-4">⛷</li>
-        <li className="mb-4">🏃‍♂️</li>
-        <li className="mb-4">🧗‍♀️</li>
-        <li className="mb-4">⛺️</li>
-        <li className="mb-4">🎾</li>
-        <li className="mb-4">🏉</li>
-      </ul>
-      <p className="mb-8 p-0 leading-[1.625] text-text">
-        Sometimes I write blogs about adventures: here&apos;s one about{' '}
-        <a href="https://starchyinscandinavia.wordpress.com/" className="text-primary hover:text-coral">Norway</a>, and another
-        about <a href="https://maraudinginmontreal.wordpress.com/" className="text-primary hover:text-coral">Canada</a>.
-      </p>
+        <div className="ab-block">
+          <div className="ab-block-label">Adventures</div>
+          <div className="ab-block-body">
+            <p>When I&apos;m not at a keyboard, I&apos;m usually outside doing some combination of:</p>
+            <ul className="ab-chips">
+              <li>🚵🏻‍♂️</li>
+              <li>⛷</li>
+              <li>🏃‍♂️</li>
+              <li>🧗‍♀️</li>
+              <li>⛺️</li>
+              <li>🎾</li>
+              <li>🏉</li>
+            </ul>
+            <p>
+              Sometimes I write blogs about adventures: here&apos;s one about{' '}
+              <a href="https://starchyinscandinavia.wordpress.com/">Norway</a>, and another about{' '}
+              <a href="https://maraudinginmontreal.wordpress.com/">Canada</a>.
+            </p>
+          </div>
+        </div>
+      </section>
     </div>
   );
 }

--- a/next-site/app/blog/[slug]/page.tsx
+++ b/next-site/app/blog/[slug]/page.tsx
@@ -1,11 +1,13 @@
 import type { Metadata } from 'next';
+import Link from 'next/link';
 import { notFound } from 'next/navigation';
 import SuggestedPosts from '@/components/suggested-posts';
 import {
-  formatDate,
+  formatDateLong,
   getPostBySlug,
   getPostSlugs,
   getSuggestedPosts,
+  readingTime,
   renderPostMdx,
 } from '@/lib/mdx';
 
@@ -42,29 +44,36 @@ export default async function BlogPostPage({ params }: PostPageProps) {
 
   const mdxContent = await renderPostMdx(post.content);
   const suggestedPosts = await getSuggestedPosts(slug, 2);
+  const topic = post.frontmatter.tags?.[0] ?? 'Essay';
 
   return (
-    <article>
-      <header>
-        <h1 className="mb-4 mt-0 font-sans text-[2.488rem] font-black leading-[0.9] tracking-[-0.025em] text-black">
-          {post.frontmatter.title}
-        </h1>
-        <p className="mb-4 mt-0 font-sans text-[1.2rem] text-text-muted">
-          {formatDate(post.frontmatter.date)}
-        </p>
+    <article className="R-article">
+      <div className="R-col">
+        <Link href="/" className="R-back">
+          <span className="arr">←</span> Back to writing
+        </Link>
+        <div className="R-kicker">
+          <span className="tag">{topic}</span>
+          <span className="sep" />
+          <span>{formatDateLong(post.frontmatter.date)}</span>
+          <span className="sep" />
+          <span>{readingTime(post.content)} min read</span>
+        </div>
+
+        <h1 className="R-title">{post.frontmatter.title}</h1>
+
+        {post.frontmatter.excerpt ? <p className="R-deck">{post.frontmatter.excerpt}</p> : null}
+
         {post.frontmatter.featuredImage ? (
-          <img
-            src={post.frontmatter.featuredImage}
-            alt={post.frontmatter.title}
-            className="mb-[50px] h-auto w-full"
-          />
+          <div className="R-hero-img">
+            <img src={post.frontmatter.featuredImage} alt={post.frontmatter.title} />
+          </div>
         ) : null}
-      </header>
 
-      <section>{mdxContent}</section>
+        <div className="R-body">{mdxContent}</div>
 
-      <hr className="my-8 h-px border-0 bg-accent" />
-      <SuggestedPosts posts={suggestedPosts} basePath="/blog" />
+        <SuggestedPosts posts={suggestedPosts} basePath="/blog" />
+      </div>
     </article>
   );
 }

--- a/next-site/app/blog/page.tsx
+++ b/next-site/app/blog/page.tsx
@@ -1,3 +1,4 @@
+import Hero from '@/components/hero';
 import PaginationNav from '@/components/pagination-nav';
 import PostList from '@/components/post-list';
 import { getAllPosts, getPostsForPage, getTotalPages, POSTS_PER_PAGE } from '@/lib/mdx';
@@ -5,6 +6,14 @@ import { getAllPosts, getPostsForPage, getTotalPages, POSTS_PER_PAGE } from '@/l
 export const metadata = {
   title: 'Blog',
 };
+
+function yearRange(posts: { frontmatter: { date: string } }[]): string {
+  if (!posts.length) return '';
+  const years = posts.map((p) => new Date(p.frontmatter.date).getFullYear());
+  const min = Math.min(...years);
+  const max = Math.max(...years);
+  return min === max ? `${min}` : `${min}—${max}`;
+}
 
 export default async function BlogIndexPage() {
   const posts = await getAllPosts();
@@ -14,7 +23,13 @@ export default async function BlogIndexPage() {
 
   return (
     <div>
-      <PostList posts={paginatedPosts} basePath="/blog" />
+      <Hero />
+      <PostList
+        posts={paginatedPosts}
+        basePath="/blog"
+        total={posts.length}
+        range={yearRange(posts)}
+      />
       <PaginationNav nextHref={nextHref} />
     </div>
   );

--- a/next-site/app/blog/page/[page]/page.tsx
+++ b/next-site/app/blog/page/[page]/page.tsx
@@ -32,7 +32,12 @@ export default async function BlogArchivePage({ params }: BlogArchivePageProps) 
 
   return (
     <div>
-      <PostList posts={paginatedPosts} basePath="/blog" />
+      <PostList
+        posts={paginatedPosts}
+        basePath="/blog"
+        startNumber={(currentPage - 1) * POSTS_PER_PAGE + 1}
+        showHead={false}
+      />
       <PaginationNav previousHref={previousHref} nextHref={nextHref} />
     </div>
   );

--- a/next-site/app/layout.tsx
+++ b/next-site/app/layout.tsx
@@ -1,11 +1,11 @@
 import type { Metadata } from 'next';
-import { JetBrains_Mono, Newsreader, Schibsted_Grotesk } from 'next/font/google';
+import { Hanken_Grotesk, JetBrains_Mono, Newsreader } from 'next/font/google';
 import SiteShell from '@/components/site-shell';
 import { rssPath, siteDescription, siteName, siteUrl } from '@/lib/site';
 import './tailwind.css';
 import './redesign.css';
 
-const schibsted = Schibsted_Grotesk({
+const hanken = Hanken_Grotesk({
   subsets: ['latin'],
   variable: '--font-sans',
   weight: ['400', '500', '600', '700'],
@@ -54,7 +54,7 @@ export default function RootLayout({
   return (
     <html
       lang="en"
-      className={`${schibsted.variable} ${newsreader.variable} ${jetbrainsMono.variable}`}
+      className={`${hanken.variable} ${newsreader.variable} ${jetbrainsMono.variable}`}
     >
       <body className="font-sans antialiased">
         <SiteShell>{children}</SiteShell>

--- a/next-site/app/layout.tsx
+++ b/next-site/app/layout.tsx
@@ -1,19 +1,27 @@
 import type { Metadata } from 'next';
-import { Domine, Source_Sans_3 } from 'next/font/google';
+import { JetBrains_Mono, Newsreader, Schibsted_Grotesk } from 'next/font/google';
 import SiteShell from '@/components/site-shell';
 import { rssPath, siteDescription, siteName, siteUrl } from '@/lib/site';
 import './tailwind.css';
+import './redesign.css';
 
-const sourceSans = Source_Sans_3({
+const schibsted = Schibsted_Grotesk({
   subsets: ['latin'],
-  variable: '--font-source-sans',
-  weight: ['400', '600', '700', '800'],
+  variable: '--font-sans',
+  weight: ['400', '500', '600', '700'],
 });
 
-const domine = Domine({
+const newsreader = Newsreader({
   subsets: ['latin'],
-  variable: '--font-domine',
-  weight: ['400', '700'],
+  variable: '--font-serif',
+  style: ['normal', 'italic'],
+  weight: ['400', '500'],
+});
+
+const jetbrainsMono = JetBrains_Mono({
+  subsets: ['latin'],
+  variable: '--font-mono',
+  weight: ['400', '500', '700'],
 });
 
 export const metadata: Metadata = {
@@ -44,8 +52,11 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
-      <body className={`${sourceSans.variable} ${domine.variable} font-serif antialiased`}>
+    <html
+      lang="en"
+      className={`${schibsted.variable} ${newsreader.variable} ${jetbrainsMono.variable}`}
+    >
+      <body className="font-sans antialiased">
         <SiteShell>{children}</SiteShell>
       </body>
     </html>

--- a/next-site/app/page.tsx
+++ b/next-site/app/page.tsx
@@ -1,6 +1,15 @@
+import Hero from '@/components/hero';
 import PaginationNav from '@/components/pagination-nav';
 import PostList from '@/components/post-list';
 import { getAllPosts, getPostsForPage, getTotalPages, POSTS_PER_PAGE } from '@/lib/mdx';
+
+function yearRange(posts: { frontmatter: { date: string } }[]): string {
+  if (!posts.length) return '';
+  const years = posts.map((p) => new Date(p.frontmatter.date).getFullYear());
+  const min = Math.min(...years);
+  const max = Math.max(...years);
+  return min === max ? `${min}` : `${min}—${max}`;
+}
 
 export default async function HomePage() {
   const posts = await getAllPosts();
@@ -10,7 +19,13 @@ export default async function HomePage() {
 
   return (
     <div>
-      <PostList posts={paginatedPosts} basePath="/blog" />
+      <Hero />
+      <PostList
+        posts={paginatedPosts}
+        basePath="/blog"
+        total={posts.length}
+        range={yearRange(posts)}
+      />
       <PaginationNav nextHref={nextHref} />
     </div>
   );

--- a/next-site/app/page/[page]/page.tsx
+++ b/next-site/app/page/[page]/page.tsx
@@ -32,7 +32,12 @@ export default async function HomeArchivePage({ params }: HomeArchivePageProps) 
 
   return (
     <div>
-      <PostList posts={paginatedPosts} basePath="/blog" />
+      <PostList
+        posts={paginatedPosts}
+        basePath="/blog"
+        startNumber={(currentPage - 1) * POSTS_PER_PAGE + 1}
+        showHead={false}
+      />
       <PaginationNav previousHref={previousHref} nextHref={nextHref} />
     </div>
   );

--- a/next-site/app/redesign.css
+++ b/next-site/app/redesign.css
@@ -1,0 +1,429 @@
+/* ============================================================
+   archy.deberker.com — redesign
+   Swiss-minimal · light · coral accent
+   Type: Schibsted Grotesk (display/UI) · Newsreader (serif body)
+         · JetBrains Mono (metadata)
+   Adapted from the Claude Design handoff (Direction A).
+   ============================================================ */
+
+:root {
+  /* cool blue-green neutral scale — near-complementary to the coral accent */
+  --paper:        #FAFCFC;
+  --ink:          #12181C;
+  --ink-soft:     #313B3F;
+  --muted:        #656F72;
+  --faint:        #9CA6A9;
+  --faintest:     #C2CBCD;
+  --line:         #E2E8E8;
+  --line-strong:  #CDD6D6;
+  --surface:      #F0F4F4;
+  --surface-2:    #E9EEEE;
+
+  --accent:       #FF5A4D;
+  --accent-ink:   color-mix(in srgb, var(--accent) 88%, #000 12%);
+  --accent-tint:  color-mix(in srgb, var(--accent) 9%, transparent);
+  --accent-line:  color-mix(in srgb, var(--accent) 28%, var(--line));
+
+  --serif: var(--font-serif), Georgia, "Times New Roman", serif;
+  --sans:  var(--font-sans), ui-sans-serif, system-ui, sans-serif;
+  --mono:  var(--font-mono), ui-monospace, "SF Mono", Menlo, monospace;
+
+  --maxw: 1040px;
+  --pad: clamp(20px, 6vw, 64px);
+}
+
+/* ---- base ---- */
+body {
+  background: var(--paper);
+  color: var(--ink);
+  font-family: var(--sans);
+  font-size: 16px;
+  line-height: 1.5;
+  letter-spacing: -0.011em;
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+}
+.site a { color: inherit; text-decoration: none; }
+
+/* page scaffold (replaces the design's artboard) */
+.page { min-height: 100vh; }
+.shell {
+  width: 100%; max-width: 1200px; margin: 0 auto;
+  min-height: 100vh; display: flex; flex-direction: column;
+}
+.page-main { flex: 1 0 auto; }
+
+/* small shared atoms */
+.eyebrow {
+  font-family: var(--mono);
+  font-size: 11px;
+  font-weight: 500;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--faint);
+}
+.mono { font-family: var(--mono); font-feature-settings: "tnum" 1; }
+
+/* ============================================================
+   TOP BAR
+   ============================================================ */
+.topbar {
+  display: flex; align-items: center; justify-content: space-between;
+  height: 76px; padding: 0 var(--pad);
+  border-bottom: 1px solid var(--line);
+  position: sticky; top: 0; z-index: 50;
+  background: rgba(250, 252, 252, 0.85);
+  backdrop-filter: blur(12px); -webkit-backdrop-filter: blur(12px);
+}
+.brand { display: flex; align-items: center; color: var(--ink); }
+.brand-full {
+  font-family: var(--mono); font-weight: 700; font-size: 15px;
+  letter-spacing: -0.01em; color: var(--ink); white-space: nowrap;
+}
+.brand-mono { display: none; }
+.nav { display: flex; align-items: center; gap: 30px; }
+.nav a {
+  position: relative;
+  font-family: var(--mono); font-size: 12px; letter-spacing: 0.06em;
+  text-transform: uppercase; color: var(--muted);
+  transition: color .15s ease;
+}
+.nav a:hover { color: var(--ink); }
+.nav a.active { color: var(--ink); }
+.nav a.active::after {
+  content: ""; position: absolute; left: 0; right: 0; bottom: -6px;
+  height: 2px; background: var(--accent);
+}
+
+/* ============================================================
+   FOOTER
+   ============================================================ */
+.foot {
+  margin-top: 80px;
+  padding: 26px var(--pad);
+  border-top: 1px solid var(--line);
+  display: flex; align-items: center; justify-content: space-between;
+  flex-wrap: wrap; gap: 16px;
+  background: var(--paper);
+}
+.foot .copy { font-family: var(--mono); font-size: 11.5px; color: var(--faint); letter-spacing: 0.02em; }
+.foot .copy a { color: var(--muted); }
+.foot .copy a:hover { color: var(--accent); }
+.foot-links { display: flex; gap: 22px; align-items: center; }
+.foot-links a {
+  font-family: var(--mono); font-size: 12px; color: var(--muted);
+  letter-spacing: 0.03em; transition: color .15s ease;
+  display: inline-flex; align-items: center; gap: 6px;
+}
+.foot-links a:hover { color: var(--accent); }
+
+/* ============================================================
+   HERO — writing page intro statement
+   ============================================================ */
+.hero { padding: 64px var(--pad) 8px; }
+.hero-wrap { max-width: var(--maxw); }
+.hero-mark { height: 112px; width: auto; display: block; margin-bottom: 32px; }
+.hero-bio {
+  max-width: 780px; margin: 0;
+  font-size: clamp(24px, 3.2vw, 34px);
+  line-height: 1.28; letter-spacing: -0.02em;
+  color: var(--ink); text-wrap: pretty;
+}
+.hero-bio a { color: var(--accent); box-shadow: 0 2px 0 var(--accent-line); transition: color .15s ease; }
+.hero-bio a:hover { color: var(--accent-ink); }
+.hero-hiring {
+  display: inline-flex; align-items: center; gap: 8px; margin-top: 28px;
+  font-family: var(--mono); font-size: 13px; letter-spacing: 0.04em;
+  color: var(--accent); transition: color .15s ease;
+}
+.hero-hiring .arr { transition: transform .2s ease; }
+.hero-hiring:hover { color: var(--accent-ink); }
+.hero-hiring:hover .arr { transform: translateX(4px); }
+
+/* ============================================================
+   WRITING — numbered editorial list (Direction A)
+   ============================================================ */
+.A-list { padding: 56px var(--pad) 24px; }
+.A-list-head {
+  max-width: var(--maxw);
+  display: flex; align-items: baseline; justify-content: space-between;
+  padding-bottom: 18px; border-bottom: 1px solid var(--ink);
+}
+.A-list-head .eyebrow { color: var(--ink); }
+.A-list-head .count { font-family: var(--mono); font-size: 12px; color: var(--faint); }
+
+.A-row {
+  max-width: var(--maxw);
+  display: grid; grid-template-columns: 36px 132px 1fr 128px;
+  grid-template-areas: "num thumb main meta";
+  gap: 28px; align-items: center;
+  padding: 22px 0; border-bottom: 1px solid var(--line);
+  transition: background .18s ease;
+  cursor: pointer;
+  color: inherit; text-decoration: none;
+}
+.A-num { grid-area: num; }
+.A-thumb { grid-area: thumb; }
+.A-main { grid-area: main; }
+.A-meta { grid-area: meta; }
+.A-row:hover { background: var(--surface); }
+.A-num {
+  font-family: var(--mono); font-size: 13px; color: var(--faint);
+  letter-spacing: 0.02em;
+}
+.A-thumb {
+  position: relative; width: 132px; aspect-ratio: 16 / 10; overflow: hidden;
+  border: 1px solid var(--line); border-radius: 2px;
+  background: linear-gradient(180deg, var(--surface) 0%, var(--surface-2) 100%);
+}
+.A-thumb img { position: absolute; inset: 0; width: 100%; height: 100%; object-fit: cover; display: block; }
+.A-thumb .n {
+  position: absolute; left: 9px; bottom: -4px;
+  font-family: var(--sans); font-weight: 600; font-size: 40px;
+  letter-spacing: -0.04em; color: #fff;
+  -webkit-text-stroke: 1px var(--faintest); line-height: 1;
+}
+.A-row:hover .A-num { color: var(--accent); }
+.A-title {
+  font-size: 27px; line-height: 1.12; font-weight: 500;
+  letter-spacing: -0.022em; color: var(--ink); margin: 0;
+  transition: color .15s ease;
+}
+.A-row:hover .A-title { color: var(--accent); }
+.A-blurb {
+  margin: 9px 0 0; font-size: 15.5px; line-height: 1.5;
+  color: var(--muted); max-width: 560px; text-wrap: pretty;
+}
+.A-meta { text-align: right; }
+.A-meta .date { font-family: var(--mono); font-size: 12.5px; color: var(--ink-soft); }
+.A-meta .sub {
+  display: block; margin-top: 6px;
+  font-family: var(--mono); font-size: 11px; letter-spacing: 0.04em;
+  color: var(--faint);
+}
+.A-tag {
+  display: inline-block; margin-top: 8px;
+  font-family: var(--mono); font-size: 10.5px; letter-spacing: 0.08em;
+  text-transform: uppercase; color: var(--muted);
+  border: 1px solid var(--line-strong); border-radius: 3px;
+  padding: 2px 7px;
+}
+
+/* pagination */
+.A-pager {
+  max-width: var(--maxw); margin: 0 var(--pad);
+  display: flex; align-items: center; justify-content: space-between;
+  padding: 28px 0 8px;
+}
+.A-pager a {
+  font-family: var(--mono); font-size: 12px; letter-spacing: 0.05em;
+  text-transform: uppercase; color: var(--muted);
+  transition: color .15s ease;
+}
+.A-pager a:hover { color: var(--accent); }
+
+/* ============================================================
+   READING VIEW — individual post
+   ============================================================ */
+.R-article { padding: 40px var(--pad) 0; }
+.R-col { max-width: 660px; margin: 0 auto; }
+.R-back {
+  display: inline-flex; align-items: center; gap: 9px; margin-bottom: 36px;
+  font-family: var(--mono); font-size: 12px; letter-spacing: 0.05em;
+  text-transform: uppercase; color: var(--muted);
+  transition: color .15s ease;
+}
+.R-back:hover { color: var(--accent); }
+.R-back .arr { transition: transform .2s ease; }
+.R-back:hover .arr { transform: translateX(-4px); }
+.R-kicker {
+  display: flex; align-items: center; gap: 14px; margin-bottom: 26px;
+  font-family: var(--mono); font-size: 11.5px; letter-spacing: 0.05em;
+  color: var(--muted); flex-wrap: wrap;
+}
+.R-kicker .tag { color: var(--accent); text-transform: uppercase; letter-spacing: 0.1em; }
+.R-kicker .sep { width: 4px; height: 4px; border-radius: 50%; background: var(--faintest); }
+.R-title {
+  font-family: var(--sans); font-size: 46px; line-height: 1.04;
+  font-weight: 500; letter-spacing: -0.032em; color: var(--ink); margin: 0;
+  text-wrap: balance;
+}
+.R-deck {
+  margin: 24px 0 0; padding-bottom: 36px; border-bottom: 1px solid var(--line);
+  font-family: var(--serif); font-size: 22px;
+  line-height: 1.45; color: var(--ink-soft); font-style: italic;
+  letter-spacing: 0; text-wrap: pretty;
+}
+.R-hero-img { margin: 36px 0 0; }
+.R-hero-img img { width: 100%; height: auto; display: block; border: 1px solid var(--line); border-radius: 3px; }
+
+/* long-form body — Newsreader serif */
+.R-body { margin-top: 40px; }
+.R-body p {
+  font-family: var(--serif); font-size: 20px; line-height: 1.62;
+  color: var(--ink-soft); letter-spacing: 0; margin: 0 0 26px;
+}
+.R-body > p:first-of-type::first-letter {
+  font-weight: 500; font-size: 62px; line-height: 0.8; float: left;
+  padding: 6px 14px 0 0; color: var(--ink);
+}
+.R-body a { color: var(--accent); box-shadow: 0 1px 0 var(--accent-line); transition: color .15s ease; }
+.R-body a:hover { color: var(--accent-ink); }
+/* heading anchors appended by rehype-autolink-headings carry no body text */
+.R-body :is(h1, h2, h3, h4, h5, h6) a { box-shadow: none; color: inherit; }
+.R-body h1, .R-body h2, .R-body h3, .R-body h4, .R-body h5, .R-body h6 {
+  font-family: var(--sans); font-weight: 500;
+  letter-spacing: -0.02em; color: var(--ink); line-height: 1.2;
+  margin: 44px 0 18px;
+}
+.R-body h1 { font-size: 30px; }
+.R-body h2 { font-size: 24px; }
+.R-body h3 { font-size: 21px; }
+.R-body h4 { font-size: 18px; }
+.R-body h5 { font-size: 15px; font-family: var(--mono); letter-spacing: 0.04em; text-transform: uppercase; color: var(--muted); }
+.R-body h6 { font-size: 13px; font-family: var(--mono); letter-spacing: 0.04em; text-transform: uppercase; color: var(--faint); }
+.R-body ul, .R-body ol {
+  font-family: var(--serif); font-size: 20px; line-height: 1.62;
+  color: var(--ink-soft); margin: 0 0 26px; padding-left: 1.4em;
+}
+.R-body ul { list-style: disc outside; }
+.R-body ol { list-style: decimal outside; }
+.R-body li { margin: 0 0 10px; padding-left: 0.3em; }
+.R-body li::marker { color: var(--faint); }
+.R-body blockquote {
+  margin: 40px 0; padding: 4px 0 4px 28px; border-left: 2px solid var(--accent);
+  font-family: var(--sans); font-size: 24px; line-height: 1.3;
+  font-weight: 500; letter-spacing: -0.022em; color: var(--ink); text-wrap: balance;
+}
+.R-body blockquote p { font-family: inherit; font-size: inherit; color: inherit; margin: 0 0 12px; }
+.R-body blockquote p:last-child { margin-bottom: 0; }
+.R-body img { width: 100%; height: auto; display: block; margin: 32px 0; border: 1px solid var(--line); border-radius: 3px; }
+/* tighten the gap below a standalone image so its caption sits with it */
+.R-body p:has(> img), .R-body p:has(> a > img) { margin-bottom: 0; }
+.R-body p:has(> img) img, .R-body p:has(> a > img) img { margin-bottom: 12px; }
+/* caption paragraphs (tagged by rehypeCaptions) */
+.R-body p.caption {
+  margin: 0 0 34px; font-family: var(--mono); font-size: 11.5px; line-height: 1.5;
+  letter-spacing: 0.01em; color: var(--faint); text-align: center; text-wrap: pretty;
+}
+.R-body p.caption a { color: var(--muted); box-shadow: none; }
+.R-body p.caption a:hover { color: var(--accent); }
+/* footnote reference markers */
+.R-body a.footnote {
+  font-family: var(--mono); font-size: 0.62em; vertical-align: super; line-height: 0;
+  padding: 0 1px; font-weight: 500; color: var(--accent); box-shadow: none;
+}
+.R-body figure { margin: 36px 0; }
+.R-body figcaption { margin-top: 12px; font-family: var(--mono); font-size: 11.5px; color: var(--faint); letter-spacing: 0.01em; text-align: center; }
+.R-body hr { height: 1px; border: 0; background: var(--line); margin: 40px 0; }
+.R-body code {
+  font-family: var(--mono); font-size: 0.86em;
+  background: var(--surface); border: 1px solid var(--line);
+  border-radius: 4px; padding: 1px 6px;
+}
+.R-body pre {
+  font-family: var(--mono); font-size: 14px; line-height: 1.55;
+  background: var(--surface); border: 1px solid var(--line);
+  border-radius: 6px; padding: 18px 20px; overflow-x: auto; margin: 0 0 26px;
+}
+.R-body pre code { background: none; border: 0; padding: 0; font-size: inherit; }
+.R-body iframe { width: 100%; border: 1px solid var(--line); border-radius: 6px; margin: 32px 0; min-height: 320px; }
+.R-body table { width: 100%; border-collapse: collapse; font-family: var(--sans); font-size: 15px; margin: 0 0 26px; }
+.R-body th { text-align: left; font-weight: 600; border-bottom: 1px solid var(--ink); padding: 8px 10px; }
+.R-body td { padding: 8px 10px; border-bottom: 1px solid var(--line); color: var(--ink-soft); vertical-align: top; }
+.R-body .icon.icon-link::after { content: " ↗"; color: var(--faint); }
+
+/* suggested posts (kept feature, redesigned look) */
+.R-next {
+  max-width: 660px; margin: 56px auto 0;
+  display: grid; grid-template-columns: 1fr 1fr; gap: 0;
+  border-top: 1px solid var(--ink);
+}
+.R-next a {
+  padding: 24px 24px 26px; cursor: pointer; transition: background .15s ease;
+  color: inherit; text-decoration: none;
+}
+.R-next a:first-child { border-right: 1px solid var(--line); }
+.R-next a:only-child { border-right: 0; }
+.R-next a:hover { background: var(--accent-tint); }
+.R-next .lab { font-family: var(--mono); font-size: 10.5px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--faint); }
+.R-next .nt { display: block; margin-top: 10px; font-size: 17px; font-weight: 500; letter-spacing: -0.015em; color: var(--ink); line-height: 1.2; }
+.R-next a:hover .nt { color: var(--accent-ink); }
+
+/* ============================================================
+   ABOUT — label | content blocks
+   ============================================================ */
+.ab-intro { padding: 64px var(--pad) 8px; }
+.ab-intro-wrap { max-width: var(--maxw); }
+.ab-intro .eyebrow { color: var(--ink); }
+.ab-banner { margin-top: 24px; }
+.ab-banner img { width: 100%; height: auto; display: block; border: 1px solid var(--line); border-radius: 4px; }
+
+.ab-blocks { padding: 8px var(--pad) 0; }
+.ab-block {
+  max-width: var(--maxw);
+  display: grid; grid-template-columns: 180px 1fr; gap: 48px;
+  padding: 52px 0; border-top: 1px solid var(--line); align-items: start;
+}
+.ab-block:first-of-type { border-top: 1px solid var(--ink); }
+.ab-block:last-of-type { border-bottom: 1px solid var(--line); }
+.ab-block-label {
+  font-family: var(--mono); font-size: 11px; letter-spacing: 0.16em;
+  text-transform: uppercase; color: var(--faint); padding-top: 6px;
+}
+.ab-block-body { max-width: 640px; }
+.ab-block-body p { margin: 0 0 18px; font-size: 16.5px; line-height: 1.6; color: var(--ink-soft); text-wrap: pretty; }
+.ab-block-body p:last-child { margin-bottom: 0; }
+.ab-block-body a { color: var(--accent); box-shadow: 0 1px 0 var(--accent-line); transition: color .15s ease; }
+.ab-block-body a:hover { color: var(--accent-ink); }
+
+.ab-chips { display: flex; flex-wrap: wrap; gap: 16px; margin: 6px 0 0; padding: 0; list-style: none; }
+.ab-chips li {
+  font-size: 26px; line-height: 1;
+  border: 0; padding: 0; margin: 0;
+}
+
+/* ============================================================
+   RESPONSIVE
+   ============================================================ */
+@media (max-width: 720px) {
+  .topbar { height: 60px; padding: 0 16px; }
+  .brand-full { display: none; }
+  .brand-mono {
+    display: inline; font-family: var(--mono); font-weight: 700;
+    font-size: 15px; letter-spacing: -0.01em; color: var(--ink);
+  }
+  .nav { gap: 16px; }
+  .nav a { font-size: 11px; letter-spacing: 0.04em; }
+
+  .hero { padding: 36px var(--pad) 4px; }
+  .hero-mark { height: 84px; margin-bottom: 24px; }
+  .A-list { padding: 32px var(--pad) 16px; }
+  .A-row {
+    grid-template-columns: 94px 1fr;
+    grid-template-areas: "thumb main" "thumb meta";
+    gap: 4px 14px; align-items: start;
+    padding: 18px 0;
+  }
+  .A-row:hover { padding-left: 0; padding-right: 0; margin: 0; background: transparent; }
+  .A-num { display: none; }
+  .A-thumb { width: 94px; align-self: start; }
+  .A-thumb .n { font-size: 30px; }
+  .A-title { font-size: 18px; }
+  .A-blurb { display: none; }
+  .A-meta { text-align: left; margin-top: 6px; }
+  .A-meta .sub { display: inline; margin: 0 0 0 10px; }
+  .A-tag { display: none; }
+
+  .R-article { padding: 36px var(--pad) 0; }
+  .R-title { font-size: 31px; }
+  .R-deck { font-size: 18px; }
+  .R-body p, .R-body ul, .R-body ol { font-size: 18px; }
+  .R-body > p:first-of-type::first-letter { font-size: 50px; }
+  .R-body blockquote { font-size: 21px; }
+  .R-next { grid-template-columns: 1fr; }
+  .R-next a:first-child { border-right: 0; border-bottom: 1px solid var(--line); }
+
+  .ab-block { grid-template-columns: 1fr; gap: 16px; padding: 36px 0; }
+  .foot { margin-top: 56px; }
+}

--- a/next-site/app/redesign.css
+++ b/next-site/app/redesign.css
@@ -1,7 +1,7 @@
 /* ============================================================
    archy.deberker.com — redesign
    Swiss-minimal · light · coral accent
-   Type: Schibsted Grotesk (display/UI) · Newsreader (serif body)
+   Type: Hanken Grotesk (display/UI) · Newsreader (serif body)
          · JetBrains Mono (metadata)
    Adapted from the Claude Design handoff (Direction A).
    ============================================================ */

--- a/next-site/components/footer.tsx
+++ b/next-site/components/footer.tsx
@@ -1,43 +1,16 @@
-'use client';
-
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faTwitter, faLinkedin, faGithub } from '@fortawesome/free-brands-svg-icons';
-
 export default function Footer() {
   return (
-    <footer className="px-0 pb-0 pt-6 text-center font-sans text-[0.833rem] text-text-muted">
-      <div className="mb-2 flex items-center justify-center gap-6 text-[1.25rem]">
-        <a href="https://twitter.com/ArchydeB" className="text-black transition-colors hover:text-coral" aria-label="Twitter">
-          <FontAwesomeIcon icon={faTwitter} className="h-5 w-5" />
+    <footer className="foot">
+      <span className="copy">© {new Date().getFullYear()} — Archy de Berker</span>
+      <div className="foot-links">
+        <a href="https://github.com/archydeberker" target="_blank" rel="noreferrer">
+          GitHub
         </a>
-        <a
-          href="https://www.linkedin.com/in/archy-de-berker/"
-          className="text-black transition-colors hover:text-coral"
-          aria-label="LinkedIn"
-        >
-          <FontAwesomeIcon icon={faLinkedin} className="h-5 w-5" />
+        <a href="https://www.linkedin.com/in/archy-de-berker/" target="_blank" rel="noreferrer">
+          LinkedIn
         </a>
-        <a
-          href="https://github.com/archydeberker"
-          className="text-black transition-colors hover:text-coral"
-          aria-label="GitHub"
-        >
-          <FontAwesomeIcon icon={faGithub} className="h-5 w-5" />
-        </a>
-        <a
-          href="/rss.xml"
-          className="font-sans text-[0.72rem] font-bold uppercase tracking-[0.18em] text-black transition-colors hover:text-coral"
-          aria-label="RSS feed"
-        >
-          RSS
-        </a>
+        <a href="/rss.xml">RSS</a>
       </div>
-      <p className="m-0">
-        © {new Date().getFullYear()}, Built with{' '}
-        <a href="https://www.gatsbyjs.com" className="text-primary hover:text-coral">
-          Gatsby
-        </a>{' '}
-      </p>
     </footer>
   );
 }

--- a/next-site/components/header.tsx
+++ b/next-site/components/header.tsx
@@ -2,96 +2,28 @@
 
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
-import { useEffect, useState } from 'react';
 
 const SITE_TITLE = 'Archy de Berker';
 
 export default function Header() {
   const pathname = usePathname();
-  const isHomeHeader = pathname === '/' || pathname === '/blog';
-  const [isScrolled, setIsScrolled] = useState(false);
-
-  useEffect(() => {
-    if (isHomeHeader) {
-      setIsScrolled(false);
-      return;
-    }
-
-    const onScroll = () => {
-      setIsScrolled(window.scrollY > 8);
-    };
-
-    onScroll();
-    window.addEventListener('scroll', onScroll, { passive: true });
-    return () => window.removeEventListener('scroll', onScroll);
-  }, [isHomeHeader]);
-
-  if (isHomeHeader) {
-    return (
-      <>
-        <img
-          src="/assets/freelance-logo.png"
-          alt="Archy in Freelancing Mode"
-          className="mx-auto block h-auto w-[150px] sm:w-[200px]"
-          width="200"
-        />
-        <h1 className="m-0 text-center font-sans text-[2.986rem] font-black leading-[0.9] tracking-[-0.025em] text-black">
-          <Link href="/" className="no-underline text-inherit">
-            {SITE_TITLE}
-          </Link>
-        </h1>
-        <div className="mx-auto mt-2 flex justify-center gap-3">
-          <Link
-            className="inline-block px-5 py-4 font-sans text-[1.44rem] font-bold text-inherit no-underline transition-colors hover:text-coral"
-            href="/"
-          >
-            Posts
-          </Link>
-          <Link
-            className="inline-block px-5 py-4 font-sans text-[1.44rem] font-bold text-inherit no-underline transition-colors hover:text-coral"
-            href="/about"
-          >
-            About
-          </Link>
-        </div>
-      </>
-    );
-  }
+  const isAbout = pathname?.startsWith('/about') ?? false;
+  const isWriting = !isAbout;
 
   return (
-    <div className="fixed inset-x-3 top-2 z-50 sm:inset-x-[25px] sm:top-[25px] sm:px-5 sm:py-5">
-      <div
-        className={`w-full px-4 py-3 transition-all duration-200 sm:mx-auto sm:max-w-3xl sm:px-5 sm:py-5 ${
-          isScrolled
-            ? 'rounded-2xl border border-gray-100 bg-white/90 shadow-sm backdrop-blur-sm'
-            : 'bg-white rounded-xl'
-        }`}
-      >
-        <div className="flex w-full items-center justify-between gap-6 sm:items-baseline sm:gap-8">
-          <div>
-            <Link
-              className="block whitespace-nowrap pr-2 font-sans text-[1.05rem] font-bold leading-none text-inherit no-underline sm:text-[1.2rem]"
-              href="/"
-            >
-              {SITE_TITLE}
-            </Link>
-          </div>
-          <div className="flex flex-1 items-center justify-end gap-1 text-right sm:block">
-            <Link
-              className="inline-block rounded-md px-1.5 py-1 font-sans font-bold text-inherit no-underline transition-colors hover:text-coral focus:text-coral sm:px-2"
-              href="/"
-            >
-              Home
-            </Link>
-            <Link
-              className="inline-block rounded-md px-1.5 py-1 font-sans font-bold text-inherit no-underline transition-colors hover:text-coral focus:text-coral sm:px-2"
-              href="/about"
-            >
-              About
-            </Link>
-          </div>
-        </div>
-      </div>
-    </div>
+    <header className="topbar">
+      <Link className="brand" href="/" aria-label="Home">
+        <span className="brand-full">{SITE_TITLE}</span>
+        <span className="brand-mono">AdeB</span>
+      </Link>
+      <nav className="nav">
+        <Link href="/" className={isWriting ? 'active' : ''}>
+          Writing
+        </Link>
+        <Link href="/about" className={isAbout ? 'active' : ''}>
+          About
+        </Link>
+      </nav>
+    </header>
   );
 }

--- a/next-site/components/hero.tsx
+++ b/next-site/components/hero.tsx
@@ -1,0 +1,16 @@
+export default function Hero() {
+  return (
+    <section className="hero">
+      <div className="hero-wrap">
+        <img className="hero-mark" src="/assets/freelance-logo.png" alt="Archy in Freelancing Mode" />
+        <p className="hero-bio">
+          I&apos;m a co-founder of <a href="https://axle.energy/">Axle Energy</a>, where we&apos;re
+          building clever software to shift energy usage to low carbon, low cost times.
+        </p>
+        <a className="hero-hiring" href="mailto:archy@axle.energy">
+          We&apos;re hiring <span className="arr">→</span>
+        </a>
+      </div>
+    </section>
+  );
+}

--- a/next-site/components/mdx-components.tsx
+++ b/next-site/components/mdx-components.tsx
@@ -1,10 +1,15 @@
 import type { MDXComponents } from 'mdx/types';
 import { cn } from '@/lib/cn';
 
+// Body elements are styled globally via the `.R-body` rules in app/redesign.css
+// (Newsreader serif body, coral accent links, Swiss-minimal headings). These
+// wrappers only carry behaviour that CSS can't express (external link rels,
+// inline-vs-block code detection, footnote/background span handling).
 export const mdxComponents: MDXComponents = {
   a: ({ className, href, ...props }) => {
     const isExternal = href?.startsWith('http');
-    const isFootnote = className?.includes('easy-footnote') ?? false;
+    const isFootnote =
+      (className?.includes('easy-footnote') ?? false) || (href?.includes('easy-footnote') ?? false);
 
     return (
       <a
@@ -12,141 +17,25 @@ export const mdxComponents: MDXComponents = {
         href={href}
         target={isExternal ? '_blank' : undefined}
         rel={isExternal ? 'noreferrer' : undefined}
-        className={cn(
-          'break-words text-primary no-underline transition-colors hover:text-coral',
-          isFootnote && 'font-sans text-[0.95rem]',
-          className,
-        )}
+        className={cn(isFootnote && 'footnote', className)}
       />
     );
   },
-  h1: ({ className, ...props }) => (
-    <h1
-      {...props}
-      className={cn(
-        'mb-6 mt-12 font-sans text-[2.488rem] font-black leading-[0.9] tracking-[-0.025em] text-black',
-        className,
-      )}
-    />
-  ),
-  h2: ({ className, ...props }) => (
-    <h2
-      {...props}
-      className={cn(
-        'mb-6 mt-12 font-sans text-[2.074rem] font-bold leading-[0.9] tracking-[-0.025em] text-heading',
-        className,
-      )}
-    />
-  ),
-  h3: ({ className, ...props }) => (
-    <h3
-      {...props}
-      className={cn(
-        'mb-6 mt-12 font-sans text-[1.728rem] font-bold leading-[0.9] tracking-[-0.025em] text-heading',
-        className,
-      )}
-    />
-  ),
-  h4: ({ className, ...props }) => (
-    <h4
-      {...props}
-      className={cn(
-        'mb-6 mt-12 font-sans text-[1.44rem] font-bold leading-[0.9] tracking-[-0.025em] text-heading',
-        className,
-      )}
-    />
-  ),
-  h5: ({ className, ...props }) => (
-    <h5
-      {...props}
-      className={cn(
-        'mb-6 mt-12 font-sans text-[1.2rem] font-bold leading-[0.9] tracking-[-0.025em] text-heading',
-        className,
-      )}
-    />
-  ),
-  h6: ({ className, ...props }) => (
-    <h6
-      {...props}
-      className={cn(
-        'mb-6 mt-12 font-sans text-[1rem] font-bold leading-[0.9] tracking-[-0.025em] text-heading',
-        className,
-      )}
-    />
-  ),
-  p: ({ className, ...props }) => (
-    <p {...props} className={cn('mb-8 p-0 leading-[1.625] text-text', className)} />
-  ),
-  ul: ({ className, ...props }) => (
-    <ul
-      {...props}
-      className={cn('mb-8 list-inside list-disc p-0 leading-[1.625] text-text', className)}
-    />
-  ),
-  ol: ({ className, ...props }) => (
-    <ol
-      {...props}
-      className={cn('mb-8 list-inside list-decimal p-0 leading-[1.625] text-text', className)}
-    />
-  ),
-  li: ({ className, ...props }) => (
-    <li {...props} className={cn('mb-4 pl-0 text-text', className)} />
-  ),
-  blockquote: ({ className, ...props }) => (
-    <blockquote
-      {...props}
-      className={cn(
-        'mb-8 border-l-4 border-primary pl-6 pr-8 text-[1.2rem] italic text-text-muted max-sm:ml-0 max-sm:pl-4',
-        className,
-      )}
-    />
-  ),
-  img: ({ className, alt, ...props }) => (
-    <img {...props} alt={alt ?? ''} loading="lazy" className={cn('my-4 h-auto w-full', className)} />
-  ),
-  iframe: ({ className, ...props }) => (
-    <iframe
-      {...props}
-      className={cn('my-8 min-h-[320px] w-full max-w-full rounded-md border border-accent', className)}
-    />
-  ),
-  table: ({ className, ...props }) => (
-    <table {...props} className={cn('mb-8 w-full border-collapse border-spacing-1', className)} />
-  ),
-  th: ({ className, ...props }) => (
-    <th
-      {...props}
-      className={cn('border-b border-accent px-2 py-2 text-left font-sans text-sm font-bold', className)}
-    />
-  ),
-  td: ({ className, ...props }) => <td {...props} className={cn('px-2 py-2 align-top', className)} />,
-  pre: ({ className, ...props }) => (
-    <pre
-      {...props}
-      className={cn('mb-8 overflow-x-auto rounded-md border border-accent bg-[#f5f7f9] p-4 font-mono text-sm text-text', className)}
-    />
-  ),
   code: ({ className, ...props }) => {
     const isCodeBlock = className?.includes('language-');
     return (
       <code
         {...props}
-        className={cn(
-          isCodeBlock
-            ? 'block w-full whitespace-pre-wrap break-words'
-            : 'rounded bg-[#f3f5f7] px-1.5 py-0.5 font-mono text-[0.9em] text-text',
-          className,
-        )}
+        className={cn(isCodeBlock && 'block w-full whitespace-pre-wrap break-words', className)}
       />
     );
   },
-  hr: ({ className, ...props }) => <hr {...props} className={cn('h-px border-0 bg-accent', className)} />,
   span: ({ className, ...props }) => {
     if (className?.includes('has-background')) {
       return (
         <span
           {...props}
-          className={cn('rounded-[10px] bg-[hsl(192,50%,90%)] text-[hsl(192,50%,20%)]', className)}
+          className={cn('rounded-[6px] bg-surface px-1 text-ink-soft', className)}
         />
       );
     }

--- a/next-site/components/pagination-nav.tsx
+++ b/next-site/components/pagination-nav.tsx
@@ -6,21 +6,17 @@ interface PaginationNavProps {
 }
 
 export default function PaginationNav({ previousHref, nextHref }: PaginationNavProps) {
+  if (!previousHref && !nextHref) {
+    return null;
+  }
+
   return (
-    <nav className="my-4 flex items-center justify-between">
+    <nav className="A-pager">
       <div>
-        {previousHref ? (
-          <Link className="font-sans text-[0.95rem] text-primary no-underline transition-colors hover:text-coral" href={previousHref}>
-            ← Previous page
-          </Link>
-        ) : null}
+        {previousHref ? <Link href={previousHref}>← Newer</Link> : null}
       </div>
       <div>
-        {nextHref ? (
-          <Link className="font-sans text-[0.95rem] text-primary no-underline transition-colors hover:text-coral" href={nextHref}>
-            Next page →
-          </Link>
-        ) : null}
+        {nextHref ? <Link href={nextHref}>Older →</Link> : null}
       </div>
     </nav>
   );

--- a/next-site/components/post-list.tsx
+++ b/next-site/components/post-list.tsx
@@ -1,51 +1,67 @@
-import { formatDate, type Post } from '@/lib/mdx';
+import { formatMonthYear, readingTime, type Post } from '@/lib/mdx';
 import Link from 'next/link';
 
 interface PostListProps {
   posts: Post[];
   basePath: string;
+  startNumber?: number;
+  total?: number;
+  range?: string;
+  showHead?: boolean;
 }
 
-export default function PostList({ posts, basePath }: PostListProps) {
+export default function PostList({
+  posts,
+  basePath,
+  startNumber = 1,
+  total,
+  range,
+  showHead = true,
+}: PostListProps) {
+  const count = total ?? posts.length;
+
   return (
-    <ol className="m-0 list-none p-0">
-      {posts.map((post) => (
-        <li key={post.slug}>
-          <article className="mb-12">
-            <Link
-              href={`${basePath}/${post.slug}`}
-              className="bg-gray-50/50 group block rounded-[10px] border border-transparent p-4 text-text no-underline transition-colors duration-200 hover:bg-gray-50  hover:cursor-pointer focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#b4d6df]"
-            >
-              <div className="grid grid-cols-1 items-start gap-x-10 sm:grid-cols-[1fr_2fr]">
-                <div>
-                  {post.frontmatter.featuredImage ? (
-                    <img
-                      src={post.frontmatter.featuredImage}
-                      alt={post.frontmatter.title}
-                      className="m-3 h-auto w-full"
-                    />
-                  ) : null}
-                </div>
-                <div>
-                  <header className="mb-2">
-                    <h2 className="mb-2 mt-0 font-sans text-3xl font-bold leading-[0.9] tracking-[-0.025em] text-primary/80 group-hover:text-primary transition-colors">
-                      {post.frontmatter.title}
-                    </h2>
-                    <span className="inline-block font-sans text-sm text-text-muted">
-                      {formatDate(post.frontmatter.date)}
-                    </span>
-                  </header>
-                  {post.frontmatter.excerpt ? (
-                    <section className=" text-text mt-1">
-                      {post.frontmatter.excerpt}
-                    </section>
-                  ) : null}
-                </div>
-              </div>
-            </Link>
-          </article>
-        </li>
-      ))}
-    </ol>
+    <section className="A-list">
+      {showHead ? (
+        <div className="A-list-head">
+          <span className="eyebrow">Writing</span>
+          <span className="count">
+            {count} essays{range ? ` · ${range}` : ''}
+          </span>
+        </div>
+      ) : null}
+
+      {posts.map((post, index) => {
+        const n = String(startNumber + index).padStart(2, '0');
+        const topic = post.frontmatter.tags?.[0];
+        return (
+          <Link
+            key={post.slug}
+            href={`${basePath}/${post.slug}`}
+            className="A-row"
+          >
+            <div className="A-num">{n}</div>
+            <div className="A-thumb">
+              {post.frontmatter.featuredImage ? (
+                <img src={post.frontmatter.featuredImage} alt={post.frontmatter.title} />
+              ) : (
+                <span className="n">{n}</span>
+              )}
+            </div>
+            <div className="A-main">
+              <h2 className="A-title">{post.frontmatter.title}</h2>
+              {post.frontmatter.excerpt ? (
+                <p className="A-blurb">{post.frontmatter.excerpt}</p>
+              ) : null}
+            </div>
+            <div className="A-meta">
+              <span className="date">{formatMonthYear(post.frontmatter.date)}</span>
+              <span className="sub">{readingTime(post.content)} min read</span>
+              {topic ? <span className="A-tag">{topic}</span> : null}
+            </div>
+          </Link>
+        );
+      })}
+    </section>
   );
 }

--- a/next-site/components/site-shell.tsx
+++ b/next-site/components/site-shell.tsx
@@ -1,8 +1,5 @@
-'use client';
-
 import Footer from '@/components/footer';
 import Header from '@/components/header';
-import { usePathname } from 'next/navigation';
 import type { ReactNode } from 'react';
 
 interface SiteShellProps {
@@ -10,23 +7,12 @@ interface SiteShellProps {
 }
 
 export default function SiteShell({ children }: SiteShellProps) {
-  const pathname = usePathname();
-  const isHomeHeader = pathname === '/' || pathname === '/blog';
-
   return (
-    <div className="relative min-h-screen p-1 text-text">
-      <div aria-hidden="true" className="absolute inset-0 overflow-hidden">
-        <div className="absolute inset-0 bg-coral" />
-        <div className="absolute -inset-[18%] animate-shell-gradient bg-shell-gradient bg-[length:160%_160%] motion-reduce:animate-none" />
-      </div>
-      <div className="relative min-h-[calc(100vh-50px)] rounded-xl bg-white">
-        <div className="mx-auto max-w-3xl px-5 py-5">
-          <header className={isHomeHeader ? 'mb-12' : 'mb-0'}>
-            <Header />
-          </header>
-          <main className={isHomeHeader ? '' : 'pt-36'}>{children}</main>
-          <Footer />
-        </div>
+    <div className="site page">
+      <div className="shell">
+        <Header />
+        <main className="page-main">{children}</main>
+        <Footer />
       </div>
     </div>
   );

--- a/next-site/components/suggested-posts.tsx
+++ b/next-site/components/suggested-posts.tsx
@@ -1,5 +1,5 @@
 import Link from 'next/link';
-import { formatDate, type Post } from '@/lib/mdx';
+import { type Post } from '@/lib/mdx';
 
 interface SuggestedPostsProps {
   posts: Post[];
@@ -14,31 +14,13 @@ export default function SuggestedPosts({ posts, basePath }: SuggestedPostsProps)
   }
 
   return (
-    <section className="mt-12 pt-4" aria-label="Suggested posts">
-      <h2 className="mb-4 mt-0 font-sans text-[1.728rem] font-bold leading-[0.9] tracking-[-0.025em] text-heading">
-        Suggested posts
-      </h2>
-      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
-        {visiblePosts.map((post) => (
-          <Link
-            key={post.slug}
-            href={`${basePath}/${post.slug}`}
-            className="block rounded-xl border border-[#d7dee7] bg-transparent p-4 text-text no-underline transition-colors hover:border-[#becad8]"
-          >
-            <h3 className="mb-2 mt-0 font-sans text-[1.2rem] font-bold leading-tight text-primary">
-              {post.frontmatter.title}
-            </h3>
-            <p className="mb-2 mt-0 font-sans text-[0.833rem] text-text-muted">
-              {formatDate(post.frontmatter.date)}
-            </p>
-            {post.frontmatter.excerpt ? (
-              <p className="m-0 hidden leading-[1.45] text-text sm:block">
-                {post.frontmatter.excerpt}
-              </p>
-            ) : null}
-          </Link>
-        ))}
-      </div>
-    </section>
+    <nav className="R-next" aria-label="Suggested posts">
+      {visiblePosts.map((post) => (
+        <Link key={post.slug} href={`${basePath}/${post.slug}`}>
+          <span className="lab">Read next</span>
+          <span className="nt">{post.frontmatter.title}</span>
+        </Link>
+      ))}
+    </nav>
   );
 }

--- a/next-site/lib/mdx.ts
+++ b/next-site/lib/mdx.ts
@@ -9,6 +9,41 @@ import { mdxComponents } from '@/components/mdx-components';
 
 const POSTS_DIR = path.join(process.cwd(), 'content/posts');
 
+// WordPress imports flattened "<figure><img><figcaption>" into a standalone
+// image followed by a caption paragraph. Tag the caption paragraphs (those that
+// start with a clear caption marker) so they render small/muted instead of as
+// full-size body text. Marker-based so we never shrink real body paragraphs.
+const CAPTION_RE = /^\s* ?\s*(source|credit|photo|image credit|fig\.|figure|©)\b/i;
+
+function rehypeCaptions() {
+  function textOf(node: { type?: string; value?: string; children?: unknown[] }): string {
+    if (node.type === 'text') return node.value ?? '';
+    if (Array.isArray(node.children)) {
+      return node.children.map((c) => textOf(c as typeof node)).join('');
+    }
+    return '';
+  }
+  type HastNode = {
+    type?: string;
+    tagName?: string;
+    properties?: { className?: unknown };
+    children?: HastNode[];
+  };
+  function walk(node: HastNode) {
+    if (!Array.isArray(node.children)) return;
+    for (const child of node.children) {
+      if (child.type === 'element' && child.tagName === 'p' && CAPTION_RE.test(textOf(child))) {
+        child.properties = child.properties ?? {};
+        const existing = child.properties.className;
+        const classes = Array.isArray(existing) ? existing : existing ? [existing] : [];
+        child.properties.className = [...classes, 'caption'];
+      }
+      walk(child);
+    }
+  }
+  return (tree: HastNode) => walk(tree);
+}
+
 export interface PostFrontmatter {
   title: string;
   date: string;
@@ -226,7 +261,7 @@ export async function renderPostMdx(source: string) {
       parseFrontmatter: false,
       mdxOptions: {
         remarkPlugins: [remarkGfm],
-        rehypePlugins: [rehypeSlug, [rehypeAutolinkHeadings, { behavior: 'append' }]],
+        rehypePlugins: [rehypeSlug, [rehypeAutolinkHeadings, { behavior: 'append' }], rehypeCaptions],
       },
     },
   });
@@ -325,4 +360,29 @@ export function formatDate(value: string): string {
     month: 'long',
     day: 'numeric',
   }).format(new Date(value));
+}
+
+export function formatDateLong(value: string): string {
+  return new Intl.DateTimeFormat('en-GB', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  }).format(new Date(value));
+}
+
+export function formatMonthYear(value: string): string {
+  return new Intl.DateTimeFormat('en-GB', {
+    year: 'numeric',
+    month: 'short',
+  }).format(new Date(value));
+}
+
+export function readingTime(content: string): number {
+  const words = content
+    .replace(/```[\s\S]*?```/g, ' ')
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/[#>*_`~\-|]/g, ' ')
+    .split(/\s+/)
+    .filter(Boolean).length;
+  return Math.max(1, Math.round(words / 200));
 }

--- a/next-site/tailwind.config.ts
+++ b/next-site/tailwind.config.ts
@@ -9,48 +9,30 @@ const config: Config = {
   ],
   theme: {
     extend: {
-      animation: {
-        'shell-gradient': 'shell-gradient 24s ease-in-out infinite',
-      },
-      backgroundImage: {
-        'shell-gradient':
-          'linear-gradient(305deg, hsl(8 100% 64%) 0%, hsl(28 98% 61%) 20%, hsl(29 63% 68%) 44%, hsl(220 69% 67%) 69%, hsl(203 100% 43%) 87%, hsl(192 100% 30%) 100%)',
-      },
       colors: {
-        primary: '#007a99',
-        coral: '#ff6147',
-        text: '#2e353f',
-        'text-muted': '#4f5969',
-        heading: '#1a202c',
-        accent: '#d1dce5',
+        // Swiss-minimal redesign tokens (mirror app/redesign.css :root)
+        paper: '#FAFCFC',
+        ink: '#12181C',
+        'ink-soft': '#313B3F',
+        muted: '#656F72',
+        faint: '#9CA6A9',
+        faintest: '#C2CBCD',
+        line: '#E2E8E8',
+        'line-strong': '#CDD6D6',
+        surface: '#F0F4F4',
+        'surface-2': '#E9EEEE',
+        accent: '#FF5A4D',
+        // kept aliases for any incidental references
+        coral: '#FF5A4D',
+        text: '#313B3F',
+        'text-muted': '#656F72',
+        heading: '#12181C',
+        primary: '#FF5A4D',
       },
       fontFamily: {
-        sans: ['var(--font-source-sans)', 'ui-sans-serif', 'system-ui', 'sans-serif'],
-        serif: ['var(--font-domine)', 'ui-serif', 'Georgia', 'serif'],
-      },
-      keyframes: {
-        'shell-gradient': {
-          '0%': {
-            backgroundPosition: '12% 38%',
-            transform: 'translate3d(-4%, -3%, 0) scale(1.08) rotate(0deg)',
-          },
-          '25%': {
-            backgroundPosition: '76% 18%',
-            transform: 'translate3d(3%, -4%, 0) scale(1.14) rotate(3deg)',
-          },
-          '50%': {
-            backgroundPosition: '92% 84%',
-            transform: 'translate3d(5%, 2%, 0) scale(1.12) rotate(0deg)',
-          },
-          '75%': {
-            backgroundPosition: '24% 96%',
-            transform: 'translate3d(-3%, 4%, 0) scale(1.15) rotate(-3deg)',
-          },
-          '100%': {
-            backgroundPosition: '12% 38%',
-            transform: 'translate3d(-4%, -3%, 0) scale(1.08) rotate(0deg)',
-          },
-        },
+        sans: ['var(--font-sans)', 'ui-sans-serif', 'system-ui', 'sans-serif'],
+        serif: ['var(--font-serif)', 'ui-serif', 'Georgia', 'serif'],
+        mono: ['var(--font-mono)', 'ui-monospace', 'SFMono-Regular', 'Menlo', 'monospace'],
       },
     },
   },


### PR DESCRIPTION
Reskins the Next site to a Swiss-minimal editorial aesthetic (from the Claude Design handoff — "Direction A"), **without changing post content or images**. Implemented iteratively against the live preview.

## What changed

**Type & color**
- New type system: **Schibsted Grotesk** (display/UI), **Newsreader** (serif reading body), **JetBrains Mono** (metadata)
- Cool **blue-green neutral scale**, chosen near-complementary to the **hot-coral** accent (`#FF5A4D`) so the accent pops
- Fixed a latent bug: font CSS variables were on `<body>` but the `--serif`/`--mono`/`--sans` tokens on `:root`, so they silently resolved to empty — moved the font vars to `<html>` so serif body and monospace metadata actually render site-wide

**Layout / components**
- **Topbar** (`header.tsx`): sticky + translucent blur, monospace wordmark left (full name on desktop, `AdeB` on mobile), nav right
- **Hero** (`hero.tsx`, new): cyclist mark, statement, subtle coral "We're hiring →" link — homepage + `/blog` only
- **Posts index** (`post-list.tsx`): numbered editorial list with thumbnails (real featured images), monospace date/read-time, topic chips; subtle grey row-hover (no layout shift)
- **Reading view** (`blog/[slug]`): kicker/deck, serif body, drop cap, "← Back to writing", restyled suggested posts
- **About** (`about/page.tsx`): label/content block layout
- **Footer**: minimal monospace links (Twitter removed throughout, per request)

**Post-body formatting fixes** (`mdx-components.tsx`, `lib/mdx.ts`, `redesign.css`)
- Restored `list-style` markers (Tailwind Preflight had stripped them) — numbered and bulleted lists
- Marker-based caption tagging (`Source:`/`Credit:`/`Photo:`/`Fig.`/`©`) → small centered monospace captions
- Footnote refs rendered as small coral superscripts

## Notes
- `public/` (logo, banners, imported post images) is gitignored and lives outside this branch; image paths are unchanged, so production rendering is unaffected.
- Verified via `next build` (all 58 routes export) and live preview on desktop + mobile.
- Caption detection is marker-based on purpose (most post-image paragraphs are genuine body text, not captions); a caption without a marker will still read as body text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)